### PR TITLE
Fixing bad reference for service logs url.

### DIFF
--- a/lib/tutum_services.rb
+++ b/lib/tutum_services.rb
@@ -28,7 +28,7 @@ class TutumServices < TutumApi
   end
 
   def logs(uuid)
-    http_get(get_url(uuid))
+    http_get(logs_url(uuid))
   end
 
   def update_url(uuid)

--- a/spec/tutum_services.rb
+++ b/spec/tutum_services.rb
@@ -33,6 +33,10 @@ describe TutumServices do
     expect(subject.stop_url("TEST")).to eq("/service/TEST/stop/")
   end
 
+  it "can get logs" do
+    expect(subject.logs_url("TEST")).to eq("/service/TEST/logs/")
+  end
+
   it "can terminate" do
     expect(subject.terminate_url("TEST")).to eq("/service/TEST/")
   end


### PR DESCRIPTION
This test does not catch this error since tests are way too basic