### PR TITLE
New initialise api that accepts username/api or tutum_auth

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    tutum (0.2.5)
+    tutum (0.2.6)
       json (~> 1.8.1)
       rest-client (~> 1.8.0)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,14 @@ To make requests, you must secure your username and [API key](https://dashboard.
 
 ```ruby
   require 'tutum'
-  session = Tutum.new(username, api_key)
+  session = Tutum.new(username: username, api_key: api_key)
+```
+
+or by using [API Roles](https://support.tutum.co/support/solutions/articles/5000524639).
+
+```ruby
+  require 'tutum'
+  session = Tutum.new(tutum_auth: tutum_auth)
 ```
 
 ## Containers

--- a/lib/tutum.rb
+++ b/lib/tutum.rb
@@ -10,16 +10,18 @@ require_relative './tutum_regions'
 require_relative './tutum_services'
 
 class Tutum
-  attr_reader :username, :api_key
+  attr_reader :username, :api_key, :tutum_auth
 
-  def initialize(username, api_key)
-    @username = username
-    @api_key = api_key
+  def initialize(*options)
+    @options = extract_options! options
+    @username = @options[:username]
+    @api_key = @options[:api_key]
+    @tutum_auth = @options[:tutum_auth]
   end
 
   def headers
     {
-      'Authorization' => "ApiKey #{@username}:#{@api_key}",
+      'Authorization' => @tutum_auth ? @tutum_auth : "ApiKey #{@username}:#{@api_key}",
       'Accept' => 'application/json',
       'Content-Type' => 'application/json'
     }
@@ -60,4 +62,18 @@ class Tutum
   def services
     @services ||= TutumServices.new(headers)
   end
+
+  private
+
+  def extract_options!(args)
+    options = {}
+    if args[0].class == String
+      options[:username] = args[0]
+      options[:api_key] = args[1]
+    else
+      options = args[0]
+    end
+    options
+  end
+
 end

--- a/spec/tutum_spec.rb
+++ b/spec/tutum_spec.rb
@@ -2,51 +2,94 @@ require_relative './spec_helper'
 
 test_username = ENV['TUTUM_USERNAME']
 test_api_key = ENV['TUTUM_API_KEY']
+test_tutum_auth = "ApiKey #{test_username}:#{test_api_key}" #best way to handle this?
 
 describe Tutum do
-  subject do
-    Tutum.new(test_username, test_api_key)
+
+  describe "Existing initialize api" do
+
+    subject do
+      Tutum.new(test_username, test_api_key)
+    end
+
+    it "has a username and apikey" do
+      expect(subject.username).to eq(test_username)
+      expect(subject.api_key).to eq(test_api_key)
+    end
+
   end
 
-  it "has a username and apikey" do
-    expect(subject.username).to eq(test_username )
-    expect(subject.api_key).to eq(test_api_key )
+  describe "New initialize api" do
+
+    subject do
+      Tutum.new(username: test_username, api_key: test_api_key)
+    end
+
+    it "has a username and apikey" do
+      expect(subject.username).to eq(test_username)
+      expect(subject.api_key).to eq(test_api_key)
+    end
+
   end
 
-  it "compiles headers" do
-    expect(subject.headers["Authorization"].length).to be > 1
-    expect(subject.headers["Accept"]).to eq("application/json")
+  describe "New initialize api with tutum_auth" do
+
+    subject do
+      Tutum.new(tutum_auth: test_tutum_auth)
+    end
+
+    it "has a tutum_auth" do
+      expect(subject.tutum_auth).to eq(test_tutum_auth)
+    end
+
+    it "compiles headers" do
+      expect(subject.headers["Authorization"].length).to be > 1
+      expect(subject.headers["Accept"]).to eq("application/json")
+    end
+
   end
 
-  it "#actions calls the actions API" do
-    expect(subject.actions).to be_a TutumActions
-  end
+  describe "Calls to api" do
 
-  it "#containers calls the containers API" do
-    expect(subject.containers).to be_a TutumContainers
-  end
+    subject do
+      Tutum.new(username: test_username, api_key: test_api_key)
+    end
 
-  it "#node_clusters class the node clusters API" do
-    expect(subject.node_clusters).to be_a TutumNodeClusters
-  end
+    it "compiles headers" do
+      expect(subject.headers["Authorization"].length).to be > 1
+      expect(subject.headers["Accept"]).to eq("application/json")
+    end
 
-  it "#node_types calls the node types API" do
-    expect(subject.node_types).to be_a TutumNodeTypes
-  end
+    it "#actions calls the actions API" do
+      expect(subject.actions).to be_a TutumActions
+    end
 
-  it "#nodes the nodes API" do
-    expect(subject.nodes).to be_a TutumNodes
-  end
+    it "#containers calls the containers API" do
+      expect(subject.containers).to be_a TutumContainers
+    end
 
-  it "#providers calls the providers API" do
-    expect(subject.providers).to be_a TutumProviders
-  end
+    it "#node_clusters class the node clusters API" do
+      expect(subject.node_clusters).to be_a TutumNodeClusters
+    end
 
-  it "#regions calls the regions API" do
-    expect(subject.regions).to be_a TutumRegions
-  end
+    it "#node_types calls the node types API" do
+      expect(subject.node_types).to be_a TutumNodeTypes
+    end
 
-  it "#services services API" do
-    expect(subject.services).to be_a TutumServices
+    it "#nodes the nodes API" do
+      expect(subject.nodes).to be_a TutumNodes
+    end
+
+    it "#providers calls the providers API" do
+      expect(subject.providers).to be_a TutumProviders
+    end
+
+    it "#regions calls the regions API" do
+      expect(subject.regions).to be_a TutumRegions
+    end
+
+    it "#services services API" do
+      expect(subject.services).to be_a TutumServices
+    end
   end
 end

--- a/spec/tutum_spec.rb
+++ b/spec/tutum_spec.rb
@@ -2,7 +2,7 @@ require_relative './spec_helper'
 
 test_username = ENV['TUTUM_USERNAME']
 test_api_key = ENV['TUTUM_API_KEY']
-test_tutum_auth = "ApiKey #{test_username}:#{test_api_key}" #best way to handle this?
+test_tutum_auth = ENV['TUTUM_AUTH'] || "ApiKey #{test_username}:#{test_api_key}" #best way to handle this?
 
 describe Tutum do
 
@@ -43,8 +43,7 @@ describe Tutum do
     end
 
     it "compiles headers" do
-      expect(subject.headers["Authorization"].length).to be > 1
-      expect(subject.headers["Accept"]).to eq("application/json")
+      expect(subject.headers["Authorization"]).to eq(test_tutum_auth)
     end
 
   end


### PR DESCRIPTION
Changed the way the Tutum.new accepts arguments so it can be used for API Roles in service containers and my changes is also backwards compatible (see)
```ruby
session = Tutum.new(username, api_key)
session = Tutum.new(username: username, api_key: api_key)
session = Tutum.new(tutum_auth: tutum_auth)
```