### PR TITLE
Add optional `json_opts` for extra JSON deserialisation features 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,9 +8,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.3.8)
     codeclimate-test-reporter (0.4.1)
       simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.0)
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
     domain_name (0.5.24)
@@ -49,6 +52,7 @@ GEM
       sexp_processor (~> 4.0)
     ruby_parser (3.6.3)
       sexp_processor (~> 4.1)
+    safe_yaml (1.0.4)
     sexp_processor (4.4.4)
     simplecov (0.9.1)
       docile (~> 1.1.0)
@@ -59,6 +63,9 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
+    webmock (1.21.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
     wrong (0.7.1)
       diff-lcs (~> 1.2.5)
       predicated (~> 0.2.6)
@@ -75,4 +82,8 @@ DEPENDENCIES
   rake (~> 10.3.2)
   rspec (~> 3.1.0)
   tutum!
+  webmock (~> 1.21)
   wrong (~> 0.7.1)
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ or by using [API Roles](https://support.tutum.co/support/solutions/articles/5000
   session = Tutum.new(tutum_auth: tutum_auth)
 ```
 
+you can specify extra json options, such as such switching on `:symbolize_name` for all response hashes.
+
+```ruby
+  session = Tutum.new(username: username, api_key: api_key, json_opts: {:symbolize_names => true}
+```
+
 ## Containers
 
 ### Create a new container

--- a/lib/tutum.rb
+++ b/lib/tutum.rb
@@ -11,13 +11,14 @@ require_relative './tutum_services'
 require_relative './tutum_stacks'
 
 class Tutum
-  attr_reader :username, :api_key, :tutum_auth
+  attr_reader :username, :api_key, :tutum_auth, :json_opts
 
   def initialize(*options)
     @options = extract_options! options
     @username = @options[:username]
     @api_key = @options[:api_key]
     @tutum_auth = @options[:tutum_auth]
+    @json_opts = @options[:json_opts]
   end
 
   def headers
@@ -29,43 +30,43 @@ class Tutum
   end
 
   def actions
-    @actions ||= TutumActions.new(headers)
+    @actions ||= TutumActions.new(headers, @json_opts)
   end
 
   def containers
-    @containers ||= TutumContainers.new(headers)
+    @containers ||= TutumContainers.new(headers, @json_opts)
   end
 
   def images
-    @images ||= TutumImages.new(headers)
+    @images ||= TutumImages.new(headers, @json_opts)
   end
 
   def node_clusters
-    @node_clusters ||= TutumNodeClusters.new(headers)
+    @node_clusters ||= TutumNodeClusters.new(headers, @json_opts)
   end
 
   def node_types
-    @node_types ||= TutumNodeTypes.new(headers)
+    @node_types ||= TutumNodeTypes.new(headers, @json_opts)
   end
 
   def nodes
-    @nodes ||= TutumNodes.new(headers)
+    @nodes ||= TutumNodes.new(headers, @json_opts)
   end
 
   def providers
-    @providers ||= TutumProviders.new(headers)
+    @providers ||= TutumProviders.new(headers, @json_opts)
   end
 
   def regions
-    @regions ||= TutumRegions.new(headers)
+    @regions ||= TutumRegions.new(headers, @json_opts)
   end
 
   def services
-    @services ||= TutumServices.new(headers)
+    @services ||= TutumServices.new(headers, @json_opts)
   end
 
   def stacks
-    @stacks ||= TutumStacks.new(headers)
+    @stacks ||= TutumStacks.new(headers, @json_opts)
   end
 
   private
@@ -75,6 +76,7 @@ class Tutum
     if args[0].class == String
       options[:username] = args[0]
       options[:api_key] = args[1]
+      options[:json_opts] = args[2]
     else
       options = args[0]
     end

--- a/lib/tutum_api.rb
+++ b/lib/tutum_api.rb
@@ -6,8 +6,9 @@ class TutumApi
   BASE_API_PATH = 'https://dashboard.tutum.co/api'
   API_VERSION = 'v1'
 
-  def initialize(headers)
+  def initialize(headers, json_opts={})
     @headers = headers
+    @json_opts = json_opts
   end
 
   def url(path)
@@ -19,21 +20,21 @@ class TutumApi
     full_path = path
     full_path += query unless params.empty?
     response = RestClient.get(url(full_path), headers)
-    JSON.parse(response)
+    JSON.parse(response, @json_opts)
   end
 
   def http_post(path, content={})
     response = RestClient.post(url(path), content.to_json, headers)
-    JSON.parse(response)
+    JSON.parse(response, @json_opts)
   end
 
   def http_patch(path, content={})
     response = RestClient.patch(url(path), content.to_json, headers)
-    JSON.parse(response)
+    JSON.parse(response, @json_opts)
   end
 
   def http_delete(path)
     response = RestClient.delete(url(path), headers)
-    JSON.parse(response)
+    JSON.parse(response, @json_opts)
   end
 end

--- a/spec/tutum_api_spec.rb
+++ b/spec/tutum_api_spec.rb
@@ -1,0 +1,71 @@
+require_relative './spec_helper'
+require 'webmock/rspec'
+
+describe TutumApi do
+
+  describe 'When given JSON options' do
+
+    subject(:tutum_api) { TutumApi.new({}, {:symbolize_names => true}) }
+
+    SERVICES = {
+        :uuid => "097f4ec3-d70a-441e-9b4f-df70a102cbd1",
+        :image_name => "trunk/hello-world:v1",
+        :name => "hello-world",
+        :linked_from_service => [
+            {
+                :name => "lb",
+            }
+        ]
+    }
+    SERVICES_JSON = JSON.generate(SERVICES)
+
+    it 'should symbolize names for get response' do
+      # given
+      stub_request(:get, "#{tutum_api.url("/test")}").to_return(:status => 200, :body => SERVICES_JSON)
+
+      # when
+      service = tutum_api.http_get("/test")
+
+      # then
+      expect(service).to eq(SERVICES)
+      expect(service[:linked_from_service][0][:name]).to eq("lb")
+    end
+
+    it 'should symbolize names for post response' do
+      # given
+      stub_request(:post, "#{tutum_api.url("/test")}").to_return(:status => 200, :body => SERVICES_JSON)
+
+      # when
+      service = tutum_api.http_post("/test", content = {})
+
+      # then
+      expect(service).to eq(SERVICES)
+      expect(service[:linked_from_service][0][:name]).to eq("lb")
+    end
+
+    it 'should symbolize names for patch response' do
+      # given
+      stub_request(:patch, "#{tutum_api.url("/test")}").to_return(:status => 200, :body => SERVICES_JSON)
+
+      # when
+      service = tutum_api.http_patch("/test")
+
+      # then
+      expect(service).to eq(SERVICES)
+      expect(service[:linked_from_service][0][:name]).to eq("lb")
+    end
+
+    it 'should symbolize names for delete response' do
+      # given
+      stub_request(:delete, "#{tutum_api.url("/test")}").to_return(:status => 200, :body => SERVICES_JSON)
+
+      # when
+      service = tutum_api.http_delete("/test")
+
+      # then
+      expect(service).to eq(SERVICES)
+      expect(service[:linked_from_service][0][:name]).to eq("lb")
+    end
+  end
+
+end

--- a/spec/tutum_spec.rb
+++ b/spec/tutum_spec.rb
@@ -1,20 +1,35 @@
 require_relative './spec_helper'
 
-test_username = ENV['TUTUM_USERNAME']
-test_api_key = ENV['TUTUM_API_KEY']
+test_username = ENV['TUTUM_USERNAME'] || "tutum_username"
+test_api_key = ENV['TUTUM_API_KEY'] || "tutum_api_key"
 test_tutum_auth = ENV['TUTUM_AUTH'] || "ApiKey #{test_username}:#{test_api_key}" #best way to handle this?
+json_opts = {}
 
 describe Tutum do
 
   describe "Existing initialize api" do
 
     subject do
-      Tutum.new(test_username, test_api_key)
+      Tutum.new(test_username, test_api_key, json_opts)
     end
 
     it "has a username and apikey" do
       expect(subject.username).to eq(test_username)
       expect(subject.api_key).to eq(test_api_key)
+    end
+
+  end
+
+  describe "Existing initialize api" do
+
+    subject do
+      Tutum.new(test_username, test_api_key, json_opts)
+    end
+
+    it "has a username and apikey" do
+      expect(subject.username).to eq(test_username)
+      expect(subject.api_key).to eq(test_api_key)
+      expect(subject.json_opts).to eq(json_opts)
     end
 
   end
@@ -31,15 +46,28 @@ describe Tutum do
     end
   end
 
+  describe "New initialize api" do
+
+    subject do
+      Tutum.new(username: test_username, api_key: test_api_key, json_opts: json_opts)
+    end
+
+    it "has a username and apikey" do
+      expect(subject.username).to eq(test_username)
+      expect(subject.api_key).to eq(test_api_key)
+      expect(subject.json_opts).to eq(json_opts)
+    end
+  end
 
   describe "New initialize api with tutum_auth" do
 
     subject do
-      Tutum.new(tutum_auth: test_tutum_auth)
+      Tutum.new(tutum_auth: test_tutum_auth, json_opts: json_opts)
     end
 
     it "has a tutum_auth" do
       expect(subject.tutum_auth).to eq(test_tutum_auth)
+      expect(subject.json_opts).to eq(json_opts)
     end
 
     it "compiles headers" do

--- a/spec/tutum_spec.rb
+++ b/spec/tutum_spec.rb
@@ -10,17 +10,18 @@ describe Tutum do
   describe "Existing initialize api" do
 
     subject do
-      Tutum.new(test_username, test_api_key, json_opts)
+      Tutum.new(test_username, test_api_key)
     end
 
     it "has a username and apikey" do
       expect(subject.username).to eq(test_username)
       expect(subject.api_key).to eq(test_api_key)
+      expect(subject.json_opts).to be_nil
     end
 
   end
 
-  describe "Existing initialize api" do
+  describe "Existing initialize api with json_opts" do
 
     subject do
       Tutum.new(test_username, test_api_key, json_opts)
@@ -43,10 +44,11 @@ describe Tutum do
     it "has a username and apikey" do
       expect(subject.username).to eq(test_username)
       expect(subject.api_key).to eq(test_api_key)
+      expect(subject.json_opts).to be_nil
     end
   end
 
-  describe "New initialize api" do
+  describe "New initialize api with json_opts" do
 
     subject do
       Tutum.new(username: test_username, api_key: test_api_key, json_opts: json_opts)

--- a/tutum.gemspec
+++ b/tutum.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 10.3.2'
   s.add_development_dependency 'wrong', '~> 0.7.1'
   s.add_development_dependency 'pry', '~> 0.10.1'
+  s.add_development_dependency 'webmock', '~> 1.21'
 end


### PR DESCRIPTION
In my current build scripts I overwrote `tutum_api` to allow for `{:symbolize_names => true}` to be switched on. It's quite handy to manipulate all the response hashes using symbols instead of strings. This might be useful for others so I added a PR.

I've added tests accordingly. Also set `tutum_username` and `tutum_api_key` in `tutum_spec` to default values so that users without environment variables can still run the tests without errors. 