### PR TITLE
Use the tutum auth header, when given username and api_key

### DIFF
--- a/lib/tutum.rb
+++ b/lib/tutum.rb
@@ -1,3 +1,5 @@
+require 'base64'
+
 require_relative './tutum_api'
 
 require_relative './tutum_actions'

--- a/lib/tutum.rb
+++ b/lib/tutum.rb
@@ -23,7 +23,7 @@ class Tutum
 
   def headers
     {
-      'Authorization' => @tutum_auth ? @tutum_auth : "ApiKey #{@username}:#{@api_key}",
+      'Authorization' => authorization_header,
       'Accept' => 'application/json',
       'Content-Type' => 'application/json'
     }
@@ -70,6 +70,10 @@ class Tutum
   end
 
   private
+
+  def authorization_header
+    @tutum_auth ? @tutum_auth : "Basic #{Base64.strict_encode64(@username + ':' + @api_key)}"
+  end
 
   def extract_options!(args)
     options = {}

--- a/spec/tutum_spec.rb
+++ b/spec/tutum_spec.rb
@@ -1,8 +1,9 @@
 require_relative './spec_helper'
+require 'base64'
 
 test_username = ENV['TUTUM_USERNAME'] || "tutum_username"
 test_api_key = ENV['TUTUM_API_KEY'] || "tutum_api_key"
-test_tutum_auth = ENV['TUTUM_AUTH'] || "ApiKey #{test_username}:#{test_api_key}" #best way to handle this?
+test_tutum_auth = ENV['TUTUM_AUTH'] || "Basic #{Base64.strict_encode64(test_username + ':' + test_api_key)}"
 json_opts = {}
 
 describe Tutum do
@@ -58,6 +59,10 @@ describe Tutum do
       expect(subject.username).to eq(test_username)
       expect(subject.api_key).to eq(test_api_key)
       expect(subject.json_opts).to eq(json_opts)
+    end
+
+    it "uses basic auth from username and apikey" do
+      expect(subject.headers["Authorization"]).to eq(test_tutum_auth)
     end
   end
 


### PR DESCRIPTION
Hi!

We found that auth was broken in prod when passing in the username and api key, so this patch changes the behaviour to produce the Basic auth header when given those credentials

![selfie-0](http://i.imgur.com/uLeZHxb.png)
